### PR TITLE
Fix microphone selection

### DIFF
--- a/recorder.py
+++ b/recorder.py
@@ -13,9 +13,8 @@ class Recorder:
         self.mapping = [c - 1 for c in channels]  # Channel numbers start with 1
         self.q = queue.Queue()
         self.channels = channels
-        self.device_info = sd.query_devices(device_id, 'input')
+        self.device_info = dict()
         self.device_id = device_id
-        self.sample_rate = self.device_info['default_samplerate']
         self.downsample = downsample
         self.window = window
         self.length = int(self.window * self.sample_rate / (1000 * self.downsample))
@@ -24,6 +23,19 @@ class Recorder:
 
         self.stream = sd.InputStream(device=self.device_id, channels=max(self.channels),
                                      samplerate=self.sample_rate, callback=self.audio_callback)
+
+    @property
+    def device_id(self):
+        return self._device_id
+
+    @device_id.setter
+    def device_id(self, device_id):
+        self._device_id = device_id
+        self.device_info = sd.query_devices(device_id, 'input')
+
+    @property
+    def sample_rate(self):
+        return self.device_info['default_samplerate']
 
     def change_device(self, device_id):
         LOG.info("Changing recorder device to {}".format(device_id))
@@ -44,7 +56,7 @@ class Recorder:
         self.is_recording = True
         self.current_file = sf.SoundFile(filename, mode='w', samplerate=int(self.sample_rate),
                                          channels=len(self.channels))
-        
+
     def stop_recording(self):
         LOG.info("Stopping recording, saved to {}".format(self.current_file.name))
         self.is_recording = False


### PR DESCRIPTION
Fixes #20 

Previously when selecting a microphone with a different sampling rate
the application would throw an exception

```
2019-11-05 09:23:00,664 - epic_narrator.controller - INFO - Changing mic
2019-11-05 09:23:00,664 - epic_narrator.recorder - INFO - Changing recorder device to 9
2019-11-05 09:23:00,679 - epic_narrator.recorder - INFO - Stream closed
2019-11-05 09:23:00,742 - epic_narrator.controller - ERROR - Traceback (most recent call last):
File "/app/bin/controller.py", line 175, in change_mic
self.recorder.change_device(mic_id)
File "/app/bin/recorder.py", line 33, in change_device
samplerate=self.sample_rate, callback=self.audio_callback)
File "/app/lib/python3.7/site-packages/sounddevice.py", line 1301, in __init__
**_remove_self(locals()))
File "/app/lib/python3.7/site-packages/sounddevice.py", line 780, in __init__
'Error opening {0}'.format(self.__class__.__name__))
File "/app/lib/python3.7/site-packages/sounddevice.py", line 2572, in _check
raise PortAudioError(errormsg, err)
sounddevice.PortAudioError: Error opening InputStream: Invalid sample rate [PaErrorCode -9997]
```

This was caused by this code

```python
def change_device(self, device_id):
LOG.info("Changing recorder device to {}".format(device_id))
self.close_stream()
self.device_id = device_id
self.stream = sd.InputStream(device=self.device_id, channels=max(self.channels),
                             samplerate=self.sample_rate, callback=self.audio_callback)
```

Note that the input stream is opened using `self.sample_rate` which is
set in the constructor

```python
class Recorder:
    def __init__(self, channels=[1], device_id=sd.default.device[0], window=200, downsample=10):
        ...
        self.device_info = sd.query_devices(device_id, 'input')
        self.device_id = device_id
        self.sample_rate = self.device_info['default_samplerate']
```

So `self.sample_rate` is always the first recording device's sample
rate. This won't cause an issue unless the device you're switching to
doesn't support that sampling rate.

This commit resolves this issue by always keeping `device_info` up to
date and changing all class attributes that are derived from
`device_info` to be properties that access the `device_info` dictionary.